### PR TITLE
fix katex in content index

### DIFF
--- a/src/components/Content.astro
+++ b/src/components/Content.astro
@@ -24,6 +24,17 @@ import ThemeIcon from "../components/ThemeIcon.astro";
   </div>
 </div>
 <script>
+  function getCleanText(element: HTMLElement) {
+    let text = "";
+    element.childNodes.forEach((node: ChildNode) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        text += node.textContent;
+      } else if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).className !== 'katex-mathml') {
+        text += getCleanText(node as HTMLElement);
+      }
+    });
+    return text;
+  }
   function addContent() {
     const headings = document.querySelectorAll("h1, h2, h3, h4, h5, h6");
 
@@ -31,7 +42,7 @@ import ThemeIcon from "../components/ThemeIcon.astro";
       let tocContent = "<ul class='overflow-auto w-full list-none m-0 p-0'>";
       let levelCounters = [0, 0, 0, 0, 0, 0];
       headings.forEach((heading) => {
-        let headingText = heading.textContent;
+        let headingText = getCleanText(heading as HTMLElement);
         const headingId = heading.id;
         const headingLevel = parseInt(heading.tagName.charAt(1), 10);
 


### PR DESCRIPTION
~谢罪，早知道把前两个typo并在这里了~

拉取侧边栏目录时，采用的是读html而不是直接从markdown里拉。如果我们有需要在标题中使用latex符号，会导致常见的katex的符号复制问题。因为heading.textContent的逻辑是提取html中所有文本部分，而katex渲染的html会例如

（如果markdown中标题为`### 关于$\gamma$和$\beta$的必要性`）

```html
<h4 id="关于\gamma和\beta的必要性">关于<span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>γ</mi></mrow><annotation encoding="application/x-tex">\gamma</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.625em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.05556em;">γ</span></span></span></span>和<span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>β</mi></mrow><annotation encoding="application/x-tex">\beta</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8889em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.05278em;">β</span></span></span></span>的必要性<a href="#关于\gamma和\beta的必要性" class="anchor"><span class="anchor-icon" data-pagefind-ignore="">#</span></a></h4>
```
![image](https://github.com/user-attachments/assets/b0d8c204-8efb-428f-8964-8ddd522e234d)
显然，默认逻辑下，显示的是：
![image](https://github.com/user-attachments/assets/70ef45ee-be41-4b24-8773-4fb96a8fa6bf)

这段代码修改了拉取逻辑，跳过了冗余的部分（即 $\gamma$ \gamma）部分
```javascript
  function getCleanText(element: HTMLElement) {
    let text = "";
    element.childNodes.forEach((node: ChildNode) => {
      if (node.nodeType === Node.TEXT_NODE) {
        text += node.textContent;
      } else if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).className !== 'katex-mathml') {
        text += getCleanText(node as HTMLElement);
      }
    });
    return text;
  }
```

修复后，符号显示正常：
![image](https://github.com/user-attachments/assets/da1e017a-82f2-473a-9c2b-04f5d803c905)

ps：上面这篇文章位于 https://blog.loping151.com/blog/2024/%E9%9D%A2%E8%AF%95%E5%A4%8D%E7%9B%98-1/
