### PR TITLE
Fix img zoom in linkcard

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -23,7 +23,7 @@ a {
   @apply rounded-xl shadow-xl;
 }
 
-.main-card img {
+.main-card img:not(.link-card img) {
   @apply rounded-xl;
 }
 


### PR DESCRIPTION
[Screencast from 2024-09-18 21-18-03.webm](https://github.com/user-attachments/assets/9908ec0f-30a0-4f56-b5a3-a57bf61ca8bd)

Ubuntu录屏不带指针所以可能不太清除。。事实上发生了：

点击友链（点击位置在图片上），然后回到自己的站点，友链的头像会放大。这是 https://github.com/EveSunMaple/Frosti/commit/de3d07122d4fe945e93906d52083c6b55195ed01 引入的新特性。

这是因为 `firend.mdx` 使用 `BaseCard` 作为版面，`rounded-xl` 通过 `main card` 样式转递给了 `link-card` 中的图片。我认为这是不符合预期的。所以增加了排除：

`src/styles/global.scss` line 26,
```scss
.main-card img:not(.link-card img) {
  @apply rounded-xl;
}
```