### PR TITLE
Fix image zoom in linkcard

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -116,10 +116,10 @@ const { title, image, includeSidebar = true } = Astro.props;
   }
 
   import mediumZoom from "medium-zoom/dist/pure";
-  mediumZoom(".main-card img", { margin: 24, background: "#00000080" });
+  mediumZoom(".main-card img:not(.link-card img)", { margin: 24, background: "#00000080" });
 
   document.addEventListener("swup:page:view", () => {
-    mediumZoom(".main-card img", { margin: 24, background: "#00000080" });
+    mediumZoom(".main-card img:not(.link-card img)", { margin: 24, background: "#00000080" });
   });
 
   document.addEventListener("DOMContentLoaded", addCopyButton);


### PR DESCRIPTION
[Screencast from 2024-09-18 21-18-03.webm](https://github.com/user-attachments/assets/9908ec0f-30a0-4f56-b5a3-a57bf61ca8bd)

Ubuntu录屏不带指针所以可能不太清楚。。事实上发生了：

点击友链（点击位置在图片上），然后回到自己的站点，友链的头像会放大。这是 https://github.com/EveSunMaple/Frosti/commit/de3d07122d4fe945e93906d52083c6b55195ed01 引入的新特性。

这是因为 `firend.mdx` 使用 `BaseCard` 作为版面，`mediumZoom` 通过 `main card` 样式转递给了 `link-card` 中的图片。我认为这是不符合预期的。所以增加了排除：

```astro
mediumZoom(".main-card img:not(.link-card img)
```

上一个改错了。。没动脑子属于是。