### PR TITLE
feat: add full-text output to RSS feed

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -16,6 +16,10 @@ export const USER_AVATAR = "/profile.webp";
 // Server and transition settings
 export const SERVER_URL = "https://demo.saroprock.com";
 
+
+//Rss full text or not
+export const RSS_FULL_TEXT = false;
+
 // Theme settings
 export const DAISYUI_THEME = {
   light: "winter",

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,16 +1,24 @@
 import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
+import { SITE_TITLE, SITE_DESCRIPTION, RSS_FULL_TEXT } from "../consts";
+import { marked } from "marked";
+
 
 export async function GET(context) {
   const posts = await getCollection("blog");
+  const items = posts.map((post) => {
+    const { body, data, slug } = post;
+    return {
+      ...data,
+      link: `/blog/${slug}/`,
+      ...(RSS_FULL_TEXT && { content: marked(body) }),
+    };
+  });
+
   return rss({
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     site: context.site,
-    items: posts.map((post) => ({
-      ...post.data,
-      link: `/blog/${post.slug}/`,
-    })),
+    items,
   });
 }


### PR DESCRIPTION
This pull request introduces a new feature to control whether the RSS feed includes full text or not. The most important changes include the addition of a new constant for this feature and modifications to the RSS feed generation to use this constant.

New feature addition:

* [`src/consts.ts`](diffhunk://#diff-9c399c46fa266bcf2be2704fbb369181726959e148e95ab548a32ef9ca9e7d47R19-R22): Added a new constant `RSS_FULL_TEXT` to control whether the RSS feed includes full text.

RSS feed generation updates:

* [`src/pages/rss.xml.js`](diffhunk://#diff-7a15000980f611dc194c1a7604cf210574459adf0effd70fd0f653c01c61f08cL3-R22): Imported the new `RSS_FULL_TEXT` constant and the `marked` library. Updated the RSS feed generation logic to include full text in the feed items if `RSS_FULL_TEXT` is set to true.consts file to toggle the feature

