### PR TITLE
chore: update Vite CSS preprocessor options for SCSS compilation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -124,4 +124,13 @@ export default defineConfig({
         }
       ]],
   },
+  vite: {
+    css: {
+      preprocessorOptions: {
+        scss: {
+          api: 'modern-compiler', 
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
* fix console SCSS warning 


**Reference link** :https://stackoverflow.com/questions/78997907/the-legacy-js-api-is-deprecated-and-will-be-removed-in-dart-sass-2-0-0

![deprecation-warning](https://github.com/user-attachments/assets/b130b019-722c-4e77-9023-906f85133035)
