### PR TITLE
chore: update yaml config in real-time during development

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import { defineConfig } from "astro/config";
 import rehypeExternalLinks from "rehype-external-links";
 import rehypeKatex from "rehype-katex";
 import remarkMath from "remark-math";
+import updateConfig from "./src/integration/updateConfig.ts";
 
 import { CODE_THEME, USER_SITE } from "./src/config.ts";
 
@@ -23,6 +24,7 @@ export default defineConfig({
     },
   },
   integrations: [
+    updateConfig(),
     mdx(),
     icon(),
     terser({

--- a/src/integration/updateConfig.ts
+++ b/src/integration/updateConfig.ts
@@ -1,0 +1,13 @@
+import path from "node:path";
+import type { AstroIntegration } from "astro";
+
+export default (): AstroIntegration => ({
+  name: "update-config",
+  hooks: {
+    "astro:config:setup": (options) => {
+      const { addWatchFile } = options;
+      addWatchFile(path.resolve("frosti.config.yaml"));
+      addWatchFile(path.resolve("src/i18n/translations.yaml"));
+    },
+  },
+});


### PR DESCRIPTION
通过 [Astro integration](https://docs.astro.build/zh-cn/reference/integrations-reference/)，实现修改 yaml 格式的相关配置文件时，Astro 开发服务器自动重新启动，从而实时应用修改