### PR TITLE
fix: hide mobile TOC button when no headings exist

### DIFF
--- a/src/components/widgets/MobileTOC.astro
+++ b/src/components/widgets/MobileTOC.astro
@@ -6,14 +6,16 @@ import { Icon } from "astro-icon/components";
 const { headings = [], showTOC = true } = Astro.props as TOCBarProps;
 ---
 
+{showTOC && headings.length > 0 && (
 <button
   id="mobile-toc-button"
   aria-label={t("label.tableOfContents")}
   class="btn btn-circle btn-md fixed bottom-20 right-6 z-50 bg-base-100 shadow-lg md:hidden opacity-0 invisible transition-all hover:scale-110"
   onclick="mobile_toc_modal.showModal()"
 >
-  <Icon name="lucide:list" class="h-5 w-5" />
+  <Icon name="lucide:list" class="w-5 h-5" />
 </button>
+)}
 
 <dialog id="mobile_toc_modal" class="modal md:hidden">
   <div class="modal-box w-10/12 max-w-md bg-base-100 rounded-lg shadow-xl">

--- a/src/components/widgets/MobileTOC.astro
+++ b/src/components/widgets/MobileTOC.astro
@@ -7,29 +7,27 @@ const { headings = [], showTOC = true } = Astro.props as TOCBarProps;
 ---
 
 {showTOC && headings.length > 0 && (
-<button
-  id="mobile-toc-button"
-  aria-label={t("label.tableOfContents")}
-  class="btn btn-circle btn-md fixed bottom-20 right-6 z-50 bg-base-100 shadow-lg md:hidden opacity-0 invisible transition-all hover:scale-110"
-  onclick="mobile_toc_modal.showModal()"
->
-  <Icon name="lucide:list" class="w-5 h-5" />
-</button>
-)}
+  <>
+    <button
+      id="mobile-toc-button"
+      aria-label={t("label.tableOfContents")}
+      class="btn btn-circle btn-md fixed bottom-20 right-6 z-50 bg-base-100 shadow-lg md:hidden opacity-0 invisible transition-all hover:scale-110"
+      onclick="mobile_toc_modal.showModal()"
+    >
+      <Icon name="lucide:list" class="w-5 h-5" />
+    </button>
 
-<dialog id="mobile_toc_modal" class="modal md:hidden">
-  <div class="modal-box w-10/12 max-w-md bg-base-100 rounded-lg shadow-xl">
-    <div class="flex justify-between items-center border-b border-base-200 pb-4">
-      <h3 class="font-medium">{t("label.tableOfContents")}</h3>
-      <form method="dialog">
-        <button class="btn btn-circle btn-ghost" aria-label={t("label.tableOfContents")}>
-          <Icon name="lucide:x" class="h-5 w-5" />
-        </button>
-      </form>
-    </div>
-    <div class="pt-4 max-h-[70vh] overflow-auto">
-      {
-        showTOC && headings.length > 0 ? (
+    <dialog id="mobile_toc_modal" class="modal md:hidden">
+      <div class="modal-box w-10/12 max-w-md bg-base-100 rounded-lg shadow-xl">
+        <div class="flex justify-between items-center border-b border-base-200 pb-4">
+          <h3 class="font-medium">{t("label.tableOfContents")}</h3>
+          <form method="dialog">
+            <button class="btn btn-circle btn-ghost" aria-label={t("label.tableOfContents")}>
+              <Icon name="lucide:x" class="h-5 w-5" />
+            </button>
+          </form>
+        </div>
+        <div class="pt-4 max-h-[70vh] overflow-auto">
           <ul class="menu menu-sm">
             {headings.map((heading) => (
               <li class="my-1">
@@ -44,29 +42,23 @@ const { headings = [], showTOC = true } = Astro.props as TOCBarProps;
               </li>
             ))}
           </ul>
-        ) : (
-          <div class="py-4 text-center text-base-content/70">
-            <p>{t("label.noContents")}</p>
-          </div>
-        )
-      }
-    </div>
-  </div>
-  <form method="dialog" class="modal-backdrop">
-    <button>close</button>
-  </form>
-</dialog>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  </>
+)}
 
 <script>
   document.addEventListener("astro:page-load", () => {
     const tocButton = document.getElementById("mobile-toc-button");
     if (!tocButton) return;
 
-    // Cache DOM elements and reduce queries
     const tocLinks = document.querySelectorAll(".mobile-toc-link");
     const headings = document.querySelectorAll("h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]");
 
-    // Use a throttled scroll handler for better performance
     let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
 
     const handleScroll = () => {
@@ -75,7 +67,6 @@ const { headings = [], showTOC = true } = Astro.props as TOCBarProps;
       scrollTimeout = setTimeout(() => {
         const currentScrollY = window.scrollY;
 
-        // Toggle button visibility
         if (currentScrollY > 300) {
           tocButton.classList.remove("opacity-0", "invisible");
           tocButton.classList.add("opacity-100", "visible");
@@ -84,21 +75,18 @@ const { headings = [], showTOC = true } = Astro.props as TOCBarProps;
           tocButton.classList.add("opacity-0", "invisible");
         }
 
-        // Update active TOC link if we have content
         if (tocLinks.length > 0 && headings.length > 0) {
           updateActiveHeading();
         }
 
         scrollTimeout = null;
-      }, 100); // Throttle to 10 updates per second maximum
+      }, 100);
     };
 
-    // More efficient active heading detection
     const updateActiveHeading = () => {
       let activeHeadingId = null;
-      const offset = 100; // Offset from top of viewport
+      const offset = 100;
 
-      // Use a reverse loop for efficiency when scrolling down (most common case)
       for (let i = headings.length - 1; i >= 0; i--) {
         const heading = headings[i];
         const rect = heading.getBoundingClientRect();
@@ -109,7 +97,6 @@ const { headings = [], showTOC = true } = Astro.props as TOCBarProps;
         }
       }
 
-      // Update active link state
       tocLinks.forEach((link) => {
         const headingId = link.getAttribute("data-mobile-heading-id");
         if (headingId === activeHeadingId) {
@@ -120,13 +107,10 @@ const { headings = [], showTOC = true } = Astro.props as TOCBarProps;
       });
     };
 
-    // Add passive scroll listener for better performance
     window.addEventListener("scroll", handleScroll, { passive: true });
 
-    // Initial check
     handleScroll();
 
-    // Clean up on page unload
     document.addEventListener("astro:before-swap", () => {
       window.removeEventListener("scroll", handleScroll);
       if (scrollTimeout) {


### PR DESCRIPTION
移动端右下角的目录按钮在文章没有标题时也会显示（滚动后出现），点击后弹出空目录，体验不好。
将按钮用 {showTOC && headings.length > 0 && (...)} 包裹，无标题时不渲染。脚本中的 if (!tocButton) return; 已能正确处理按钮不存在的情况。